### PR TITLE
fix(PngCompressor): for #12

### DIFF
--- a/lib/sprockets/image_compressor/png_compressor.rb
+++ b/lib/sprockets/image_compressor/png_compressor.rb
@@ -8,19 +8,23 @@ module Sprockets
       end
 
       def compress(content)
-        compressed_png_data = ""
+        compressed_png_data = content
         Tempfile.open ["in_file", ".png"] do |in_file|
           in_file.binmode
           out_file_path = in_file.path + ".optimized.png"
           in_file.write content
           in_file.close
-          out = `#{binary_path} #{in_file.path} #{out_file_path} 2>&1`
-          in_file.delete
 
-          File.open out_file_path, "rb" do |out_file|
-            compressed_png_data = out_file.read
+          begin
+            out = `#{binary_path} #{in_file.path} #{out_file_path} 2>&1`
+
+            File.open out_file_path, "rb" do |out_file|
+              compressed_png_data = out_file.read
+            end
+            File.unlink out_file_path
+          rescue Errno::ENOENT => e
+            # error during compression so out_file not found ...
           end
-          File.unlink out_file_path
         end
         compressed_png_data
       end


### PR DESCRIPTION
This will fix #12.
I'm facing the same issue and I found this is png image error. In my case, it's [admin_notes_icon](https://github.com/gregbell/active_admin/blob/master/app/assets/images/active_admin/admin_notes_icon.png).
I tried to compile that file using cli and it will error, so here's a quick fix.
- don't delete in_file
- catch exception during compression
