### PR TITLE
Consolidated and fixed file reading methods between compressor classes.

### DIFF
--- a/lib/sprockets/image_compressor/jpg_compressor.rb
+++ b/lib/sprockets/image_compressor/jpg_compressor.rb
@@ -15,8 +15,7 @@ module Sprockets
           file.close
 
           out = `#{binary_path} --strip-all #{file.path} 2>&1`
-          file.open
-          compressed_jpg_data = file.read
+          compressed_jpg_data = IO.binread(file.path)
         end
         compressed_jpg_data
       end

--- a/lib/sprockets/image_compressor/png_compressor.rb
+++ b/lib/sprockets/image_compressor/png_compressor.rb
@@ -16,10 +16,7 @@ module Sprockets
           in_file.close
 
           out = `#{binary_path} #{in_file.path} #{out_file_path} 2>&1`
-
-          File.open out_file_path, "rb" do |out_file|
-            compressed_png_data = out_file.read
-          end
+          compressed_png_data = IO.binread(out_file_path)
           File.unlink out_file_path
         end
         compressed_png_data


### PR DESCRIPTION
The jpg_compressor class was not reading the compressed file in binary mode. I changed the read method and modified png_compressor to match methodology.
