### PR TITLE
Allow for finding system binaries on Windows systems as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.1
+  # 2.1.0 throws exception until issue is resolved: https://github.com/travis-ci/travis-ci/issues/2220
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y jpegoptim pngcrush

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Image compressor processor for Sprockets
 
+[![Build Status](https://travis-ci.org/JakeTheSnake3p0/sprockets-image_compressor.svg?branch=master)](https://travis-ci.org/JakeTheSnake3p0/sprockets-image_compressor)
+
 Sprockets preprocessor to losslessly compress .png and .jpg images using [pngcrush](http://pmt.sourceforge.net/pngcrush/) and [jpegoptim](http://www.kokkonen.net/tjko/projects.html).
 
 ## Integration with Rails 3.1+

--- a/lib/sprockets/image_compressor.rb
+++ b/lib/sprockets/image_compressor.rb
@@ -1,4 +1,5 @@
 require "sprockets/image_compressor/version"
+require "sprockets/image_compressor/binary_finder"
 require "sprockets/image_compressor/png_compressor"
 require "sprockets/image_compressor/jpg_compressor"
 require "sprockets/image_compressor/integration"

--- a/lib/sprockets/image_compressor/base.rb
+++ b/lib/sprockets/image_compressor/base.rb
@@ -18,7 +18,14 @@ module Sprockets
 
       def try_system_binary
         system_binary = `which #{@name}`.chomp
-        system_binary if system_binary.length > 0
+        if system_binary.length > 0
+          raise """
+            Your system says the executable '#{@name}' resides in '#{system_binary}', but the file is inaccessible!
+            """ unless File.exists?(system_binary)
+          system_binary
+        else
+          false
+        end
       end
 
       def try_vendored_binaries

--- a/lib/sprockets/image_compressor/base.rb
+++ b/lib/sprockets/image_compressor/base.rb
@@ -17,15 +17,21 @@ module Sprockets
       private
 
       def try_system_binary
-        system_binary = `which #{@name}`.chomp
-        if system_binary.length > 0
-          raise """
-            Your system says the executable '#{@name}' resides in '#{system_binary}', but the file is inaccessible!
-            """ unless File.exists?(system_binary)
-          system_binary
-        else
-          false
+        system_binary = nil
+        [:which, :where].each do |find|
+          # which/where may return two or more results separated by a newline. Use the first
+          system_binary = `#{find} #{@name}`.chomp.split(/[\r\n]/).compact.first
+          # If results are obtained, convert the string into proper notation
+          # (i.e., C:\something into C:/something)...but do not set the result
+          # if the file is inaccessible
+          if system_binary.length > 0
+            system_binary = File.join(system_binary.split(/[\\\/]/))
+            # Break if the file is inaccessible
+            break if File.exists?(system_binary)
+            system_binary = nil
+          end
         end
+        system_binary
       end
 
       def try_vendored_binaries

--- a/lib/sprockets/image_compressor/base.rb
+++ b/lib/sprockets/image_compressor/base.rb
@@ -7,7 +7,7 @@ module Sprockets
 
     class Base
       def binary_path
-        @binary_path ||= BinaryFinder.new(@name).to_s
+        @binary_path ||= BinaryFinder.new(@name).path
       end
     end
 

--- a/lib/sprockets/image_compressor/base.rb
+++ b/lib/sprockets/image_compressor/base.rb
@@ -2,45 +2,14 @@ require "tempfile"
 
 module Sprockets
   module ImageCompressor
+
     GEM_ROOT = File.expand_path File.join(File.dirname(__FILE__), "../../../")
 
     class Base
       def binary_path
-        @binary_path ||= begin
-          try_system_binary or try_vendored_binaries or raise """
-            Can't find an installed version of #{@name}, and none of the vendored binaries seem to work.
-            Please install #{@name}, or open an issue on the project page at https://github.com/botandrose/sprockets-image_compressor
-          """
-        end
-      end
-
-      private
-
-      def try_system_binary
-        system_binary = nil
-        [:which, :where].each do |find|
-          # which/where may return two or more results separated by a newline. Use the first
-          system_binary = `#{find} #{@name}`.chomp.split(/[\r\n]/).compact.first
-          # If results are obtained, convert the string into proper notation
-          # (i.e., C:\something into C:/something)...but do not set the result
-          # if the file is inaccessible
-          if system_binary.length > 0
-            system_binary = File.join(system_binary.split(/[\\\/]/))
-            # Break if the file is inaccessible
-            break if File.exists?(system_binary)
-            system_binary = nil
-          end
-        end
-        system_binary
-      end
-
-      def try_vendored_binaries
-        # use the first vendored binary that doesn't shit the bed when we ask for its version
-        vendored_binaries = Dir["#{GEM_ROOT}/bin/#{@name}.*"].sort
-        vendored_binaries.find do |path|
-          system("#{path} -version 2> /dev/null > /dev/null")
-        end
+        @binary_path ||= BinaryFinder.new(@name).to_s
       end
     end
+
   end
 end

--- a/lib/sprockets/image_compressor/binary_finder.rb
+++ b/lib/sprockets/image_compressor/binary_finder.rb
@@ -7,16 +7,15 @@ module Sprockets
       # Return the executable location (or nil)
       def initialize(binary_name)
         @binary_name = binary_name
+      end
+
+      def path
         @binary_path ||= begin
-          try_system_binary or try_vendored_binaries or raise """
+          try_system_binary or try_vendored_binaries or raise Errno::ENOENT, """
               Can't find an installed version of #{ @binary_name }, and none of the vendored binaries seem to work.
               Please install #{ @binary_name }, or open an issue on the project page at https://github.com/botandrose/sprockets-image_compressor
             """
         end
-      end
-
-      def to_s
-        @binary_path
       end
 
 
@@ -65,6 +64,7 @@ module Sprockets
         # use the first vendored binary that doesn't shit the bed when we ask for its version
         vendored_binaries = Dir["#{GEM_ROOT}/bin/#{ @binary_name }.*"].sort
         vendored_binaries.find do |path|
+          raise path.inspect
           system("#{ path } -version 2> /dev/null > /dev/null")
         end
       end

--- a/lib/sprockets/image_compressor/binary_finder.rb
+++ b/lib/sprockets/image_compressor/binary_finder.rb
@@ -56,7 +56,7 @@ module Sprockets
           # If we have a path and the binary is accessible, return it.
           # Otherwise, raise an error because we have an inaccessible file!
           system_binary = File.join(system_binary.split(/[\\\/]/))
-          raise "sprockets-image_compressor found #{ system_binary } but could not access it!" unless File.exists?(system_binary)
+          system_binary = nil unless File.exists?(system_binary)
         end
         system_binary
       end

--- a/lib/sprockets/image_compressor/binary_finder.rb
+++ b/lib/sprockets/image_compressor/binary_finder.rb
@@ -1,0 +1,76 @@
+module Sprockets
+  module ImageCompressor
+    class BinaryFinder
+
+      # Detect the OS and use the proper procedure
+      # for detecting the installed binary location.
+      # Return the executable location (or nil)
+      def initialize(binary_name)
+        @binary_name = binary_name
+        @binary_path ||= begin
+          try_system_binary or try_vendored_binaries or raise """
+              Can't find an installed version of #{ @binary_name }, and none of the vendored binaries seem to work.
+              Please install #{ @binary_name }, or open an issue on the project page at https://github.com/botandrose/sprockets-image_compressor
+            """
+        end
+      end
+
+      def to_s
+        @binary_path
+      end
+
+
+
+      # Try to use known OS 'finder' methods.
+      # Return the first one that doesn't fail,
+      # but default to 'which' even if all else fails.
+      def self.system_method
+        # If system() call returns nil, the binary
+        # doesn't exist, or at least can't be called
+        # without directory context
+        [:which, :where].each do |f|
+          return f unless system(f.to_s).nil?
+        end
+
+        # If neither 'which', nor 'where' work, use old
+        # Windows terminal commands to find it. If not using
+        # Windows, default to 'which' anyway
+        Gem.win_platform? ? "for %i in (#{ @binary_name }) do @echo.   %~$PATH:i" : 'which'
+      end
+      
+      def system_method
+        @finder ||= BinaryFinder::system_method
+      end
+
+
+
+    private
+
+      def try_system_binary
+        system_binary = `#{ system_method } #{ @binary_name }`.chomp.split(/[\r\n]/).compact.first
+        system_binary.strip! rescue nil
+        # If results are obtained, convert the string into proper notation
+        # (i.e., C:\something into C:/something)...but raise an error
+        # if the file is inaccessible for some reason (bad cygwin install for example)
+        if !system_binary.nil? and system_binary.length > 0
+          # If we have a path and the binary is accessible, return it.
+          # Otherwise, raise an error because we have an inaccessible file!
+          system_binary = File.join(system_binary.split(/[\\\/]/))
+          raise "sprockets-image_compressor found #{ system_binary } but could not access it!" unless File.exists?(system_binary)
+        end
+        system_binary
+      end
+
+      def try_vendored_binaries
+        # use the first vendored binary that doesn't shit the bed when we ask for its version
+        vendored_binaries = Dir["#{GEM_ROOT}/bin/#{ @binary_name }.*"].sort
+        vendored_binaries.find do |path|
+          system("#{ path } -version 2> /dev/null > /dev/null")
+        end
+      end
+
+
+
+    end
+  end
+end

--- a/lib/sprockets/image_compressor/jpg_compressor.rb
+++ b/lib/sprockets/image_compressor/jpg_compressor.rb
@@ -15,8 +15,7 @@ module Sprockets
           file.close
 
           out = `#{binary_path} --strip-all #{file.path} 2>&1`
-          file.open
-          compressed_jpg_data = file.read
+          compressed_jpg_data = IO.binread(file.path)
         end
         compressed_jpg_data
       end

--- a/lib/sprockets/image_compressor/jpg_compressor.rb
+++ b/lib/sprockets/image_compressor/jpg_compressor.rb
@@ -13,7 +13,7 @@ module Sprockets
           file.binmode
           file.write content
           file.close
-
+          
           out = `#{binary_path} --strip-all #{file.path} 2>&1`
           compressed_jpg_data = IO.binread(file.path)
         end

--- a/lib/sprockets/image_compressor/png_compressor.rb
+++ b/lib/sprockets/image_compressor/png_compressor.rb
@@ -14,7 +14,7 @@ module Sprockets
           out_file_path = in_file.path + ".optimized.png"
           in_file.write content
           in_file.close
-
+          
           out = `#{binary_path} #{in_file.path} #{out_file_path} 2>&1`
           compressed_png_data = IO.binread(out_file_path)
           File.unlink out_file_path

--- a/lib/sprockets/image_compressor/png_compressor.rb
+++ b/lib/sprockets/image_compressor/png_compressor.rb
@@ -16,10 +16,7 @@ module Sprockets
           in_file.close
 
           out = `#{binary_path} #{in_file.path} #{out_file_path} 2>&1`
-
-          File.open out_file_path, "rb" do |out_file|
-            compressed_png_data = out_file.read
-          end
+          compressed_png_data = IO.binread(out_file_path)
           File.unlink out_file_path
         end
         compressed_png_data

--- a/lib/sprockets/image_compressor/version.rb
+++ b/lib/sprockets/image_compressor/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Imagecompressor
-    VERSION = "0.2.3"
+    VERSION = "0.2.4"
   end
 end

--- a/lib/sprockets/image_compressor/version.rb
+++ b/lib/sprockets/image_compressor/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Imagecompressor
-    VERSION = "0.2.4"
+    VERSION = "0.2.5"
   end
 end

--- a/spec/binary_finder_spec.rb
+++ b/spec/binary_finder_spec.rb
@@ -44,7 +44,7 @@ describe Sprockets::ImageCompressor::BinaryFinder do
         allow(finder).to receive(:try_system_binary).and_return(nil)
         allow(finder).to receive(:try_vendored_binaries).and_return(nil)
 
-        expect(finder.path).to raise_error(Errno::ENOENT)
+        expect{finder.path}.to raise_error(Errno::ENOENT)
       end
 
     end

--- a/spec/binary_finder_spec.rb
+++ b/spec/binary_finder_spec.rb
@@ -7,10 +7,6 @@ describe Sprockets::ImageCompressor::BinaryFinder do
 
   describe "#binary_path" do
 
-    # before(:each) do
-    #   finder.send "@binary_path=nil"
-    # end
-
     context "when binary is installed" do
 
       it "prefers the system's binary" do

--- a/spec/binary_finder_spec.rb
+++ b/spec/binary_finder_spec.rb
@@ -1,0 +1,45 @@
+require "sprockets/image_compressor"
+
+describe Sprockets::ImageCompressor::BinaryFinder do
+  # Whether we're searching for jpegoptim or pngcrush is irrelevant to testing
+  let(:finder) { Sprockets::ImageCompressor::BinaryFinder.new(:jpegoptim) }
+  let(:gem_root) { Sprockets::ImageCompressor::GEM_ROOT }
+
+  describe "#binary_path" do
+
+    context "when binary is installed" do
+
+      it "prefers the system's binary" do
+        # Assume that the program has found a local file
+        allow(finder).to receive(:try_system_binary).and_return("/path/to/binary")
+        # It should return that path
+        expect(finder.to_s).to eq("/path/to/binary")
+      end
+
+    end
+
+    context "when binary is missing and we're on a supported system" do
+
+      it "falls back to a vendored binary" do
+        # Assume that the program has NOT found a local file
+        allow(finder).to receive(:try_system_binary).and_return(nil)
+        # It should return the vendored binary path
+        expect(finder.to_s).to include("#{gem_root}/bin/binary")
+      end
+
+    end
+
+    context "when binary is missing and we're on an unsupported system" do
+
+      it "raises hell" do
+        # Assume that the program has NOT found a local file and the vendored
+        # binaries aren't operable, an error should be raised
+        allow(finder).to receive(:try_system_binary).and_return(nil)
+        allow(finder).to receive(:try_vendored_binaries).and_return(nil)
+
+        expect(finder.to_s).to raise_exception
+      end
+
+    end
+  end
+end

--- a/spec/binary_finder_spec.rb
+++ b/spec/binary_finder_spec.rb
@@ -7,10 +7,6 @@ describe Sprockets::ImageCompressor::BinaryFinder do
 
   describe "#binary_path" do
 
-    # before(:each) do
-    #   finder.send "@binary_path=nil"
-    # end
-
     context "when binary is installed" do
 
       it "prefers the system's binary" do
@@ -44,7 +40,7 @@ describe Sprockets::ImageCompressor::BinaryFinder do
         allow(finder).to receive(:try_system_binary).and_return(nil)
         allow(finder).to receive(:try_vendored_binaries).and_return(nil)
 
-        expect(finder.path).to raise_error(Errno::ENOENT)
+        expect{finder.path}.to raise_error(Errno::ENOENT)
       end
 
     end

--- a/spec/binary_finder_spec.rb
+++ b/spec/binary_finder_spec.rb
@@ -7,13 +7,17 @@ describe Sprockets::ImageCompressor::BinaryFinder do
 
   describe "#binary_path" do
 
+    # before(:each) do
+    #   finder.send "@binary_path=nil"
+    # end
+
     context "when binary is installed" do
 
       it "prefers the system's binary" do
         # Assume that the program has found a local file
         allow(finder).to receive(:try_system_binary).and_return("/path/to/binary")
         # It should return that path
-        expect(finder.to_s).to eq("/path/to/binary")
+        expect(finder.path).to eq("/path/to/binary")
       end
 
     end
@@ -23,8 +27,11 @@ describe Sprockets::ImageCompressor::BinaryFinder do
       it "falls back to a vendored binary" do
         # Assume that the program has NOT found a local file
         allow(finder).to receive(:try_system_binary).and_return(nil)
+        # We cannot actually test local files as they are system-dependant (would not pass in Windows)
+        # using current implementation)
+        allow(finder).to receive(:try_vendored_binaries).and_return("#{gem_root}/bin/jpegoptim")
         # It should return the vendored binary path
-        expect(finder.to_s).to include("#{gem_root}/bin/binary")
+        expect(finder.path).to eq("#{gem_root}/bin/jpegoptim")
       end
 
     end
@@ -37,7 +44,7 @@ describe Sprockets::ImageCompressor::BinaryFinder do
         allow(finder).to receive(:try_system_binary).and_return(nil)
         allow(finder).to receive(:try_vendored_binaries).and_return(nil)
 
-        expect(finder.to_s).to raise_exception
+        expect(finder.path).to raise_error(Errno::ENOENT)
       end
 
     end

--- a/spec/compressors/jpg_compressor_spec.rb
+++ b/spec/compressors/jpg_compressor_spec.rb
@@ -1,40 +1,5 @@
 require "sprockets/image_compressor"
 
 describe Sprockets::ImageCompressor::JpgCompressor do
-  let(:compressor) { Sprockets::ImageCompressor::JpgCompressor.new }
-  let(:gem_root) { Sprockets::ImageCompressor::GEM_ROOT }
-
-  describe "#binary_path" do
-    context "when jpegoptim is installed" do
-      before do
-        compressor.should_receive(:`).with("which jpegoptim").and_return("/path/to/jpegoptim\n")
-      end
-
-      it "prefers the system's binary" do
-        compressor.binary_path.should == "/path/to/jpegoptim"
-      end
-    end
-
-    context "when jpegoptim is missing and we're on a supported system" do
-      before do
-        compressor.should_receive(:`).with("which jpegoptim").and_return("")
-        compressor.should_receive(:system).and_return(true)
-      end
-
-      it "falls back to a vendored binary" do
-        compressor.binary_path.should include("#{gem_root}/bin/jpegoptim")
-      end
-    end
-
-    context "when jpegoptim is missing and we're on an unsupported system" do
-      before do
-        compressor.should_receive(:`).with("which jpegoptim").and_return("")
-        compressor.should_receive(:system).twice.and_return(false)
-      end
-
-      it "raises hell" do
-        lambda { compressor.binary_path }.should raise_exception
-      end
-    end
-  end
+  
 end

--- a/spec/compressors/png_compressor_spec.rb
+++ b/spec/compressors/png_compressor_spec.rb
@@ -1,47 +1,5 @@
 require "sprockets/image_compressor"
 
 describe Sprockets::ImageCompressor::PngCompressor do
-  let(:compressor) { Sprockets::ImageCompressor::PngCompressor.new }
-  let(:gem_root) { Sprockets::ImageCompressor::GEM_ROOT }
-
-  describe "#binary_path" do
-    context "when pngcrush is installed" do
-      before do
-        compressor.should_receive(:`).with("which pngcrush").and_return("/path/to/pngcrush\n")
-      end
-
-      it "prefers the system's binary" do
-        compressor.binary_path.should == "/path/to/pngcrush"
-      end
-    end
-
-    context "when pngcrush is missing and we're on a supported system" do
-      before do
-        compressor.should_receive(:`).with("which pngcrush").and_return("")
-        compressor.should_receive(:system).and_return(true)
-      end
-
-      it "falls back to a vendored binary" do
-        compressor.binary_path.should include("#{gem_root}/bin/pngcrush")
-      end
-    end
-
-    context "when pngcrush is missing and we're an unsupported system" do
-      before do
-        compressor.should_receive(:`).with("which pngcrush").and_return("")
-        compressor.should_receive(:system).twice.and_return(false)
-      end
-
-      it "raises hell" do
-        lambda { compressor.binary_path }.should raise_exception
-      end
-    end
-  end
-
-  describe "#compress" do
-    it "returns uncompressable content as-is with a warning" do
-      compressor.should_receive(:warn)
-      compressor.compress("asdf").should == "asdf"
-    end
-  end
+  
 end

--- a/spec/integration/sprockets_integration_spec.rb
+++ b/spec/integration/sprockets_integration_spec.rb
@@ -15,19 +15,19 @@ describe "sprockets integration" do
   it "should compress pngs" do
     big_response = get "/largepng.png"
     small_response = get "/smallpng.png"
-    big_response.headers["Content-Length"].should == small_response.headers["Content-Length"]
-    big_response.body.should == small_response.body
+    expect(big_response.headers["Content-Length"]).to eq(small_response.headers["Content-Length"])
+    expect(big_response.body).to eq(small_response.body)
   end
 
   it "should compress jpgs" do
     big_response = get "/largejpg.jpg"
     small_response = get "/smalljpg.jpg"
-    big_response.headers["Content-Length"].should == small_response.headers["Content-Length"]
-    big_response.body.should == small_response.body
+    expect(big_response.headers["Content-Length"]).to eq(small_response.headers["Content-Length"])
+    expect(big_response.body).to eq(small_response.body)
   end
 
   it "should still serve text assets" do
     response = get "/test.css"
-    response.status.should == 200
+    expect(response.status).to eq(200)
   end
 end

--- a/sprockets-image_compressor.gemspec
+++ b/sprockets-image_compressor.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "sprockets"
 
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "byebug"


### PR DESCRIPTION
sprockets-image_compressor vaguely fails when precompiling, but makes no mention of why. I tracked down my problem to the fact that the executable was "found", but still inaccessible - which meant that the output file was never created. The gem now looks to see if the executable file actually exists.
